### PR TITLE
Update spark

### DIFF
--- a/generated/main/scala/Simulation.scala
+++ b/generated/main/scala/Simulation.scala
@@ -11,7 +11,7 @@ object Simulation extends App {
   var currentTurn: Int = 0
   var totalTurn: Int = 100
   var currentTime: Double = 0
-  var totalTime: Double = 4
+  var totalTime: Double = 10
 
   var monitor_enabled: Boolean = false
 
@@ -45,7 +45,8 @@ object Simulation extends App {
     val start = System.nanoTime()
     println("Monitor is enabled: " + monitor_enabled)
     while (currentTurn <= totalTurn && currentTime <= totalTime) {
-      println("(Time " + BigDecimal(currentTime).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble + " Turn " + currentTurn + ")" )
+      println("(Time " + BigDecimal(currentTime).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
+        + " Turn " + currentTurn + ")" )
       collect(currentTurn)
       waitLabels("time") = actors.length
 
@@ -54,6 +55,7 @@ object Simulation extends App {
       actors = actors.map { a =>
         {
           a.cleanSendMessage
+            .checkInterrupts(currentTime)
             .addReceiveMessages(Random.shuffle(mx.getOrElse(a.id, List())))
             .run_until(currentTurn)
         }

--- a/generated/main/scala/SimulationSpark.scala
+++ b/generated/main/scala/SimulationSpark.scala
@@ -1,8 +1,7 @@
-import Simulation.{actors, currentTime, currentTurn}
 import meta.deep.runtime.Actor.{AgentId, initLabelVals, minTurn, proceedGroups, proceedLabel, waitLabels, waitTurnList}
-import meta.deep.runtime.{Actor, Message}
+import meta.deep.runtime.{Actor, Message, SparkSims}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.{SparkConf, SparkContext, broadcast}
 
 object SimulationSpark extends App {
 
@@ -10,16 +9,14 @@ object SimulationSpark extends App {
     new SparkConf().setMaster("local").setAppName("ECONOMIC_SIMULATION")
   @transient lazy val sc: SparkContext = new SparkContext(conf)
 
-  var actors: RDD[(AgentId, Actor)] = _
+  var actors: RDD[Actor] = _
   var currentTurn: Int = 0
-  var totalTurn: Int = 100
+  var totalTurns: Int = 100
   var currentTime: Double = 0
   var totalTime: Double = 10
-//  var timer = 0
-//  var until = 100
 
   def init(): Unit = {
-    actors = sc.parallelize(generated.InitData.initActors).map(x => (x.id, x))
+    actors = sc.parallelize(generated.InitData.initActors)
     initLabelVals()
   }
 
@@ -28,10 +25,10 @@ object SimulationSpark extends App {
     currentTurn += minTurn()
     currentTime += proceedLabel("time")
 
-    // update the turn counter for Sims
-    actors.mapValues(i => {
+    actors = actors.map(i => {
       i.currentTime = currentTime
       i.currentTurn = currentTurn
+      i
     })
 
     waitTurnList.clear()
@@ -43,26 +40,32 @@ object SimulationSpark extends App {
 
     init()
     val start = System.nanoTime()
+    waitLabels("time") = actors.count().toInt
 
-    while (currentTurn <= totalTurn) {
+    while (currentTurn <= totalTurns && currentTime <= totalTime) {
+
+      println("(Time " + BigDecimal(currentTime).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
+        + " Turn " + currentTurn + ")" )
 
       // Checkpoint actors object, so that it does not get too big
       // see: https://stackoverflow.com/questions/36421373/java-lang-stackoverflowerror-and-checkpointing-on-spark
-      println("TIMER", currentTurn)
-      if (currentTurn % 50 == 0) {
-        actors.checkpoint()
-      }
+      // Result in non-serializable error
 
-      waitLabels("time") = actors.count().toInt
+//      if (currentTurn % 50 == 0) {
+//        actors.checkpoint()
+//      }
 
       //Execute all actors
-      actors = actors.mapValues(a => {
-        a.cleanSendMessage.run_until(currentTurn)
-      })
+      actors = actors.map(x => SparkSims.cleanSendMessage(x))
+          .map(x => SparkSims.checkInterrupts(x, currentTime))
+          .map(x => SparkSims.run_until(x, currentTurn))
+          .cache()    // cache to persist it, otherwise Sims get different ids across runs
 
-      //Collect all messages from the round
-      val dMessages: RDD[(AgentId, List[Message])] = actors
-        .flatMap(_._2.getSendMessages)
+      // Collect all messages from the round
+      // leftOuterJoin results in closure bug: it captures agentId as a class variable, not an object variable
+      // Use broadcast variable to share read-only collected messages. Can't have transformations within a transformation
+      val messageMap: scala.collection.Map[AgentId, List[Message]] = actors
+        .flatMap(SparkSims.getSendMessages)
         .map(x => (x.receiverId, x))
         .combineByKey(
           (message: Message) => {
@@ -73,22 +76,15 @@ object SimulationSpark extends App {
           },
           (l1: List[Message], l2: List[Message]) => {
             l1 ::: l2
-          }
-        )
-        .cache()
+          }).collectAsMap()
 
-      //Distribute messages for the next round
-      actors = actors
-        .leftOuterJoin(dMessages)
-        .mapValues { x =>
-          x._1.checkInterrupts(currentTime).addReceiveMessages(x._2.getOrElse(List()))
-//                    x._1.addReceiveMessages(x._2.getOrElse(List()))
-          x._1
-        }
-        .cache()
+      val dMessages = sc.broadcast(messageMap)
 
-      proceedGroups()
-//      timer += 1
+      actors = actors.map(actor => {
+        SparkSims.addReceiveMessages(actor, dMessages)
+      })
+
+      proceed()
     }
 
     val end = System.nanoTime()

--- a/src/main/scala/meta/classLifting/Lifter.scala
+++ b/src/main/scala/meta/classLifting/Lifter.scala
@@ -187,7 +187,7 @@ class Lifter {
                            liftCode(elseBody, actorSelfVariable, clasz))
         f.asInstanceOf[Algo[T]]
 
-      case code"SpecialInstructions.handleMessages()  " =>
+      case code"SpecialInstructions.handleMessages()" =>
         //generates an IfThenElse for each of this class' methods, which checks if the called method id is the same
         //as any of this class' methods, and calls the method if it is
         val resultMessageCall = Variable[Any]
@@ -238,7 +238,6 @@ class Lifter {
         }
 
         val f =
-//          LetBinding(None,
             LetBinding(
               Some(waitCounter),
               ScalaCode(code"0.0"),
@@ -263,7 +262,6 @@ class Lifter {
         }
 
         val f =
-//          LetBinding(None,
             LetBinding(
               Some(waitCounter),
               ScalaCode(code"0.0"),
@@ -289,7 +287,6 @@ class Lifter {
         }
 
         val f =
-//          LetBinding(None,
               LetBinding(
                 Some(waitCounter),
                 ScalaCode(code"0"),
@@ -301,6 +298,29 @@ class Lifter {
                     Wait()))),
             )
         f.asInstanceOf[Algo[T]]
+
+      case code"SpecialInstructions.interrupt($interval: Double, (() => ${MethodApplication(msg)}))" =>
+        val argss: ListBuffer[OpenCode[_]] = ListBuffer[OpenCode[_]]() // in the reverse order
+        var mtd: IR.MtdSymbol = msg.symbol
+
+//        var innerMtd: IR.Predef.base.Code[Any, _] = msg.args.head.head
+
+//        argss.append(msg.args.tail.head.head)
+//        while (mtd.toString() == "Function1.apply") {
+//          innerMtd match {
+//            case code"($sa: $st) => ${MethodApplication(msg2)}: Any" =>
+//              mtd = msg2.symbol
+//              innerMtd = msg2.args.head.head
+//              argss.append(msg2.args.tail.head.head)
+//          }
+//        }
+//
+//        argss.remove(argss.length-1)
+
+        Interrupt(actorSelfVariable.toCode,
+                  interval,
+                  methodsIdMap(mtd),
+                  List(argss.toList))
 
       // asynchronously call a remote method
       // arguments to an async call needs to be passed as variables instead of constants.

--- a/src/main/scala/meta/classLifting/SpecialInstructions.scala
+++ b/src/main/scala/meta/classLifting/SpecialInstructions.scala
@@ -20,4 +20,7 @@ object SpecialInstructions {
 
   // Handle incoming messages
   def handleMessages(): Unit = ???
+
+  // Interrupt for time
+  def interrupt(interval: Double, method: (()=>Any)): Unit = ???
 }

--- a/src/main/scala/meta/deep/algo/Interrupt.scala
+++ b/src/main/scala/meta/deep/algo/Interrupt.scala
@@ -1,0 +1,45 @@
+package meta.deep.algo
+
+import meta.deep.IR.Predef._
+import meta.deep.runtime.{Actor}
+
+case class Interrupt[R](actor: OpenCode[Actor],
+                         delay: OpenCode[Double],
+                         methodId: Int,
+                         argss: List[List[OpenCode[_]]])
+                          (implicit val R: CodeType[R])
+  extends Algo[R] {
+
+  override def codegen(): Unit = {
+    val methodIdC = Const(methodId)
+
+    // Convert arguments to opencode, so that can be used as argument inside of OpenCode
+    val initCodeO: OpenCode[List[List[Any]]] = code"Nil"
+    val convertedArgs: OpenCode[List[List[Any]]] =
+      argss.foldRight(initCodeO)((x, y) => {
+        val initCode: OpenCode[List[Any]] = code"Nil"
+        val z: OpenCode[List[Any]] =
+          x.foldRight(initCode)((a, b) => code"$a::$b")
+        code"$z::$y"
+      })
+
+    val f1: OpenCode[Unit] =
+      code"""
+        val sender = $actor;
+        val receiver = $actor;
+        val requestMessage = meta.deep.runtime.RequestMessage(sender.id, receiver.id, $methodIdC, $convertedArgs);
+        sender.registerInterrupt($delay, requestMessage);
+        ${AlgoInfo.returnValue} := null
+        ()"""
+
+    AlgoInfo.stateGraph.append(
+      AlgoInfo.EdgeInfo("Interrupt",
+        AlgoInfo.CodeNodePos(AlgoInfo.posCounter),
+        AlgoInfo.CodeNodePos(AlgoInfo.posCounter + 1),
+        f1
+      ))
+
+    AlgoInfo.nextPos()
+  }
+}
+

--- a/src/main/scala/meta/deep/codegen/CreateCode.scala
+++ b/src/main/scala/meta/deep/codegen/CreateCode.scala
@@ -136,7 +136,15 @@ class CreateCode(initCode: OpenCode[List[Actor]], storagePath: String, packageNa
       run_until = run_until.replace(self, "this")
     })
 
-    def parents: String = s"${compiledActorGraph.parentNames.head}${compiledActorGraph.parentNames.tail.foldLeft("")((a,b) => a + " with " + b)}"
+    // Add Serializable to keep Spark happy
+    def parents: String = {
+      val ans: String = s"${compiledActorGraph.parentNames.head}${compiledActorGraph.parentNames.tail.foldLeft("")((a,b) => a + " with " + b)}"
+      if (compiledActorGraph.parentNames.contains("Serializable")){
+        ans
+      } else {
+        ans + " with Serializable"
+      }
+    }
 
     createClass(compiledActorGraph.name, parameters, initParams, initVars, run_until, parents);
   }

--- a/src/main/scala/meta/example/time_example/README.md
+++ b/src/main/scala/meta/example/time_example/README.md
@@ -1,4 +1,6 @@
-Time advances only when all the Sims are waiting for time. Due to the random number, your output may not be the same as below. The point is to see that when Sim 2 is waiting for time, the timer value doesn't change right away. Only when Sim1 also waits on time does the timer advances. You can also define an interrupt that occurs at a given time. Please note that since a given time may corresponds to multiple turns, as in the output below for time 5, add some additional check if you want the interrupt to happen only once.  
+Time advances only when all the Sims are waiting for time. Due to the random number, your output may not be the same as below. The point is to see that when Sim 2 is waiting for time, the timer value doesn't change right away. Only when Sim1 also waits on time does the timer advances. You can also define an interrupt that occurs at a given time. 
+If you define a local "interrupt handler" that does something when time is ready, as in the commented out section of the code, please note that since a given time may corresponds to multiple turns, as in the output below for time 5, add some additional check if you want the interrupt to happen only once.  
+If you use the specialInstructions.interrupt(), then the interrupt only occurs once. The following sample output is for the specialInstruction version of the interrupt. 
 
 Expected output: 
 ```
@@ -16,16 +18,20 @@ Wait time has finished 1
 Wait time! 1
 (Time 1.0 Turn 5)
 ...
-(Time 4.5 Turn 30)
-Wait time! 1
+(Time 5.0 Turn 30)
 (Time 5.0 Turn 31)
-(Time 5.0 Turn 32)
-Wait time has finished 1
-Alert! 5.0 has elapsed
+Wait time finished 1
+Time is up!
+Wait time 0.5 Id 1
+Wait time finished 2
+Time is up!
 Wait turn!
-Wait time has finished 2
-Alert! 5.0 has elapsed
+(Time 5.0 Turn 32)
 Wait turn!
 (Time 5.0 Turn 33)
-Alert! 5.0 has elapsed
+Wait time 1.0 Id 2
+(Time 5.5 Turn 34)
+(Time 5.5 Turn 35)
+Wait time finished 1
+Wait turn!
 ```

--- a/src/main/scala/meta/example/time_example/Sim.scala
+++ b/src/main/scala/meta/example/time_example/Sim.scala
@@ -1,7 +1,7 @@
 package meta.example.time_example
 
 import meta.deep.runtime.Actor
-import meta.classLifting.SpecialInstructions.{handleMessages, waitTime, waitTurns}
+import meta.classLifting.SpecialInstructions._
 import squid.quasi.lift
 
 import scala.util.Random.nextBoolean
@@ -9,15 +9,24 @@ import scala.util.Random.nextBoolean
 @lift
 class Sim(var time: Double) extends Actor {
 
-  def interrupt(targetTime: Double): Unit = {
-    if (targetTime == currentTime){
-      println("Alert! " + targetTime + " time elapsed")
-    }
+//  def interrupt(targetTime: Double): Unit = {
+//    if (targetTime == currentTime){
+//      println("Alert! " + targetTime + " time elapsed")
+//    }
+//  }
+
+  def timeUp(): Unit = {
+    println("Time is up!")
   }
 
+  var delay: Int = 5
+
   def main(): Unit = {
+    interrupt(delay, ()=>timeUp())
+
     while (true) {
-      interrupt(5)
+//      interrupt(5)
+
       if (nextBoolean()){
         println("Wait turn!")
         //        println("Wait turn! " + " Id " + id)


### PR DESCRIPTION
- Closure issue caused by capturing agentId as a class variable rather than the object variable. Changed dMessages from RDD to broadcast read-only variable, and created singleton methods to replace the class methods (getSendMessages, etc)
- Updated support for label group, time, and interrupt
-  Updated "createCode" to include "Serializable" in class inheritance
-  Commented out Checkpoint; caused non-serializable bug. Not a top priority for now, fix later
